### PR TITLE
Fix URL address.

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -98,5 +98,5 @@ MolSSI offers 1-2 day workshops as well as online tutorial materials. All tutori
 ## Quantum Mechanics Tools
 **Description**: The qm-tools workshop introduces several types of quantum chemistry calculations a student might use, including geometry optimizations, inter- and intra-molecular potential energy scans, and energy calculations.  Some basic file parsing and data analysis is also discussed.
 
-[{% octicon book %} View Materials](https://github.com/MolSSI-Education/qm-tools/) | 
-[{% octicon mark-github} View GitHub Repository %} View GitHub Repository](https://molssi-education.github.io/qm-tools/)
+[{% octicon book %} View Materials](https://molssi-education.github.io/qm-tools/) | 
+[{% octicon mark-github} View GitHub Repository %} View GitHub Repository](https://github.com/MolSSI-Education/qm-tools/)


### PR DESCRIPTION
Link for QM tools is incorrect and redirect to wrong website. Fix it by swapping URL address between the web page and its Github repo.