### PR TITLE
fix: 'Resouces' tabs navbar when scrolled

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -71,6 +71,7 @@ button .tablink {
 	position: relative;
 	top: 0;
 	left: 0;
+	z-index: 0;
 }
 
 .site-header {


### PR DESCRIPTION
in smaller screen would be on top of the main navbar

Why: z-index of `.navbar` was set for the `.navbar.resources` as well