### PR TITLE
add publications tab and data

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ header_pages:
   - events.md
   - map.md
   - calendar.md
+  - publications.md
   - request.md
 
 social-links:

--- a/_data/publications/books.yml
+++ b/_data/publications/books.yml
@@ -1,0 +1,5 @@
+- title: "Teaching Programming across the Chemistry Curriculum"
+  link: https://pubs.acs.org/isbn/9780841298194
+  publisher: ACS Symposium Series
+  editors: Ashley Ringer McDonald, Jessica A. Nash
+  description: "Programming and computational science is an essential part of chemistry, yet some curricula still do not prioritize its inclusion. This work contains a collection of strategies, activities, and resources available to incorporate programming into all levels of the chemistry curriculum, with a focus on how the programming learning objectives are integrated with chemistry learning objectives. Chapters highlight best practices in software development, emphasize their importance to the future of computational molecular sciences, and describe challenges instructors might face in implementing programming in their own curriculum."

--- a/_data/publications/papers.yml
+++ b/_data/publications/papers.yml
@@ -1,0 +1,13 @@
+- title: "Building capacity for undergraduate education and training in computational molecular science: A collaboration between the MERCURY consortium and the Molecular Sciences Software Institute"
+  journal: International Journal of Quantum Chemistry
+  authors: Ashley Ringer McDonald,Jessica A. Nash,Paul S. Nerenberg,K. Aurelia Ball,Olaseni Sode,Jonathon J. Foley IV,Theresa L. Windus,T. Daniel Crawford
+  publication_date: 2020-07-04
+  doi: 10.1002/qua.26359
+  link: https://onlinelibrary.wiley.com/doi/full/10.1002/qua.26359
+
+- title: "MolSSI Education: Empowering the Next Generation of Computational Molecular Scientists"
+  journal: Computing in Science and Engineering
+  authors: Jessica A. Nash, Mohammad Mostafanejad, T. Daniel Crawford, Ashley Ringer McDonald
+  publication_date: 2022-04-03
+  doi: 10.22541/au.164910777.74730983/v2
+  link: https://www.authorea.com/users/455341/articles/559292-molssi-education-empowering-the-next-generation-of-computational-molecular-scientists?commit=db93afd78a7d3bb53e89f3b5e0beddb05be15552

--- a/_data/publications/papers.yml
+++ b/_data/publications/papers.yml
@@ -11,3 +11,10 @@
   publication_date: 2022-04-03
   doi: 10.22541/au.164910777.74730983/v2
   link: https://www.authorea.com/users/455341/articles/559292-molssi-education-empowering-the-next-generation-of-computational-molecular-scientists?commit=db93afd78a7d3bb53e89f3b5e0beddb05be15552
+
+- title: "Free and open source software for computational chemistry education"
+  journal: WIREs Computational Molecular Science
+  authors: Susi Lehtola, Antti J. Karttunen
+  publication_date: 2022-03-23
+  doi: 10.1002/wcms.1610
+  link: https://wires.onlinelibrary.wiley.com/doi/full/10.1002/wcms.1610

--- a/publications.md
+++ b/publications.md
@@ -13,7 +13,7 @@ layout: default
 <ol>
 
 {%- for item in site.data.publications.books -%}
-    <li> <a href="{{item.link}}">{{ item.title }}</a>  
+    <li> <a href="{{item.link}}">{{ item.title }}</a>;  
     {{ item.publisher }}  
     <blockquote>
         {{ item.description }} 
@@ -25,7 +25,7 @@ layout: default
 ### Journal Articles
 <ol>
 {%- for item in sorted_pubs -%}
-    <li> <a href="{{item.link}}">{{ item.title }}</a>   
+    <li> <a href="{{item.link}}">{{ item.title }}</a>;   
     <i>{{ item.journal }}</i>,
     {{ item.authors }},
     {{ item.publication_date }},

--- a/publications.md
+++ b/publications.md
@@ -1,0 +1,35 @@
+---
+title: Publications
+layout: default
+---
+
+# MolSSI Education Publications  
+<br>
+
+{% assign sorted_pubs = (site.data.publications.papers | sort: 'publication_date' | reverse) %}
+
+### Books
+
+<ol>
+
+{%- for item in site.data.publications.books -%}
+    <li> <a href="{{item.link}}">{{ item.title }}</a>  
+    {{ item.publisher }}  
+    <blockquote>
+        {{ item.description }} 
+    </blockquote>
+    </li>
+{%- endfor %}
+</ol>
+
+### Journal Articles
+<ol>
+{%- for item in sorted_pubs -%}
+    <li> <a href="{{item.link}}">{{ item.title }}</a>   
+    <i>{{ item.journal }}</i>,
+    {{ item.authors }},
+    {{ item.publication_date }},
+    {{ item.doi }} 
+    </li>
+{%- endfor %}
+</ul>


### PR DESCRIPTION
This PR adds a publications page. The same general approach that is used for `resources` is used for publications. Data is added to a yaml file in `_data/publications`, and info is populated using liquid on the publications page. Publications are separated into books and articles.